### PR TITLE
Annotation processor

### DIFF
--- a/annotations/src/main/kotlin/bg/o/sim/annotations/ExposedModel.kt
+++ b/annotations/src/main/kotlin/bg/o/sim/annotations/ExposedModel.kt
@@ -1,0 +1,8 @@
+package bg.o.sim.annotations
+/**
+ * Regrettably does not entail super models walking about au naturel.
+ * Still cool tho! Will share the detail if and when I manage to coax the thing into working.
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.SOURCE)
+annotation class ExposedModel(val mappingRoot: String)

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -1,41 +1,58 @@
-apply plugin: 'java-library'
 apply plugin: 'kotlin'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlin-spring'
 apply plugin: 'eclipse'
 apply plugin: 'org.springframework.boot'
 apply plugin: 'io.spring.dependency-management'
+apply plugin: 'idea'
 
-dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
 
-    compile('org.springframework.boot:spring-boot-starter-cache')
-    compile('org.springframework.boot:spring-boot-starter-data-mongodb')
-    compile('org.springframework.boot:spring-boot-starter-data-mongodb-reactive')
-    compile('org.springframework.boot:spring-boot-starter-data-rest')
-//    compile('org.springframework.boot:spring-boot-starter-security')
-//    compile('org.springframework.boot:spring-security-web')
-    compile("org.springframework.boot:spring-boot-starter-actuator")
-    compile('org.springframework.boot:spring-boot-starter-webflux')
-    compile('org.springframework.boot:spring-boot-starter-web')
-
-    compile('com.fasterxml.jackson.module:jackson-module-kotlin')
-
-    compile('org.springframework.session:spring-session-core')
-
-    testCompile('org.springframework.boot:spring-boot-starter-test')
-    testCompile('io.projectreactor:reactor-test')
-    testCompile('org.springframework.restdocs:spring-restdocs-mockmvc')
-    testCompile('org.springframework.security:spring-security-test')
-
-    implementation "com.google.auto.service:auto-service:1.0-rc4"
-    kapt "com.google.auto.service:auto-service:1.0-rc4"
-}
 
 compileKotlin {
     kotlinOptions.jvmTarget = "1.8"
 }
 compileTestKotlin {
     kotlinOptions.jvmTarget = "1.8"
+}
+
+//kapt {
+//    generateStubs = true
+//}
+//idea {
+//    module {
+//        // Tell idea to mark the folder as generated sources
+//        generatedSourceDirs += file("$buildDir/generated/source/kaptKotlin/")
+//    }
+//}
+//sourceSets.main.java.srcDir file("$buildDir/generated/source/kaptKotlin/main/")
+
+dependencies {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
+
+    implementation('org.springframework.boot:spring-boot-starter-cache')
+    implementation('org.springframework.boot:spring-boot-starter-data-mongodb')
+    implementation('org.springframework.boot:spring-boot-starter-data-mongodb-reactive')
+    implementation('org.springframework.boot:spring-boot-starter-data-rest')
+//    implementation('org.springframework.boot:spring-boot-starter-security')
+//    implementation('org.springframework.boot:spring-security-web')
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation('org.springframework.boot:spring-boot-starter-webflux')
+    implementation('org.springframework.boot:spring-boot-starter-web')
+
+    implementation('com.fasterxml.jackson.module:jackson-module-kotlin')
+
+    implementation('org.springframework.session:spring-session-core')
+
+    testImplementation('org.springframework.boot:spring-boot-starter-test')
+    testImplementation('io.projectreactor:reactor-test')
+    testImplementation('org.springframework.restdocs:spring-restdocs-mockmvc')
+    testImplementation('org.springframework.security:spring-security-test')
+
+    implementation "com.google.auto.service:auto-service:1.0-rc4"
+    kapt "com.google.auto.service:auto-service:1.0-rc4"
+
+    implementation project(':annotations')
+    implementation project(':aprocessor')
+    kapt project(':aprocessor')
 }

--- a/application/src/main/kotlin/bg/o/sim/Model.kt
+++ b/application/src/main/kotlin/bg/o/sim/Model.kt
@@ -1,0 +1,7 @@
+package bg.o.sim
+
+import bg.o.sim.annotations.ExposedModel
+import bg.o.sim.web.BaseEntity
+
+@ExposedModel("mdl")
+data class Model(val counter: Int, val post : String):BaseEntity()

--- a/application/src/main/kotlin/bg/o/sim/model/TransactionRepo.kt
+++ b/application/src/main/kotlin/bg/o/sim/model/TransactionRepo.kt
@@ -1,5 +1,6 @@
 package bg.o.sim.model
 
+import bg.o.sim.annotations.ExposedModel
 import bg.o.sim.web.BaseEntity
 import bg.o.sim.web.CrudApiController
 import org.springframework.beans.factory.annotation.Autowired
@@ -26,5 +27,10 @@ data class Transaction(
         val origin_id: String,
         val destination_id: String,
         val amount: Long
+) : BaseEntity()
+
+@ExposedModel("tst")
+data class Testerino(
+        val name: String
 ) : BaseEntity()
 

--- a/application/src/main/resources/application.properties
+++ b/application/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 spring.data.mongodb.host=127.0.0.1
 spring.data.mongodb.port=27017
 spring.data.mongodb.database=people
+server.port=19000

--- a/aprocessor/build.gradle
+++ b/aprocessor/build.gradle
@@ -10,6 +10,9 @@ dependencies {
     implementation "com.squareup:kotlinpoet:1.0.0-RC1"
     implementation "com.google.auto.service:auto-service:1.0-rc4"
     kapt "com.google.auto.service:auto-service:1.0-rc4"
+
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation project(':annotations')
 }
 
 compileKotlin {

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,6 @@ allprojects {
 group 'bg.o.sim'
 version '0.1.0'
 
-task clean(type: Delete) {
-    delete rootProject.buildDir
-}
+//task clean(type: Delete) {
+//    delete rootProject.buildDir
+//}

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ allprojects {
 }
 
 group 'bg.o.sim'
-version '0.1.0'
+version '0.1.1-SNAPSHOT'
 
 //task clean(type: Delete) {
 //    delete rootProject.buildDir


### PR DESCRIPTION
Added an `Annotation Processor` for the `@ExposedModel` annotation.
It:
* Generates a file using a String template (to be reviewed for a more flexible solution) for each class that:
  - is annotated with `@ExposedModel'
  - AND is a `BaseEntity` sub-class
* Generated files are then picked-up by `Spring Web`, `Spring Mongo` and `Spring Rest`, resulting in an API endpoint exposing a MongoDB collection in the configured Mongo instance. 